### PR TITLE
Docker image building fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN echo "America/New_York" | tee /etc/timezone \
 		tzdata \
     && locale-gen en_US.UTF-8 \
 	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-	&& echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list
+	&& . /etc/lsb-release \
+	&& echo "deb https://cloud.r-project.org/bin/linux/ubuntu ${DISTRIB_CODENAME}-cran40/" >> /etc/apt/sources.list
 
 # STAGE 1 - R and R packages
 FROM stage0 as stage1


### PR DESCRIPTION
There was a hard-coded ubuntu release in the Dockerfile command that downloaded R. We are using the latest ubuntu base image so when it updated it broke the R download. A dynamic variable was added in order for the R download to work as new releases happen.