### PR TITLE
fixed a bug around logr_sd in input.R

### DIFF
--- a/neobam/input.R
+++ b/neobam/input.R
@@ -102,7 +102,7 @@ get_sos = function(sos_file, reach_id) {
   window_params$upperbound_logDb = max(var.get.nc(n_grp, "upperbound_logDb")[index])
 
   window_params$r_hat = exp(var.get.nc(n_grp, "logr_hat")[indexes])
-  window_params$r_sd = exp(var.get.nc(n_grp, "logr_hat")[indexes])
+  window_params$r_sd = exp(var.get.nc(n_grp, "logr_sd")[indexes])
   window_params$lowerbound_r = min(exp(var.get.nc(n_grp, "lowerbound_logr")[index]))
   window_params$upperbound_r = max(exp(var.get.nc(n_grp, "upperbound_logr")[index]))
 


### PR DESCRIPTION
# WHY  
Described in #4. 

# WHAT  
05d7d515b7f226fd47143f7b6068bfccd0a228b8: fixed `logr_sd` to read `logr_sd` (previously `logr_hat`) from an input netcdf.

# DISCLAIMER
@Travis-Simmons 
I did not check whether this code works in/with production environment/data, as I do not have an access to them (not have an information to mimic the environment/input data either). So if you could check it that would be very helpful...! Thanks!